### PR TITLE
bump nuxt parse version to 0.2.6

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "hasInstallScript": true,
       "dependencies": {
-        "@sidestream-tech/nuxt-sidebase-parse": "^0.2.4",
+        "@sidestream-tech/nuxt-sidebase-parse": "^0.2.6",
         "sqlite3": "^5.0.11",
         "typeorm": "^0.3.9",
         "zod": "^3.18.0"
@@ -2768,9 +2768,9 @@
       }
     },
     "node_modules/@sidestream-tech/nuxt-sidebase-parse": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@sidestream-tech/nuxt-sidebase-parse/-/nuxt-sidebase-parse-0.2.4.tgz",
-      "integrity": "sha512-QbEAIGHKm0drVlOYSagZMT2eB27rYkwijEIxAjPSrL+soul/aKWUjqc6mL9/koUdUT+DwsTF31Ldd2ruiPNmfg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@sidestream-tech/nuxt-sidebase-parse/-/nuxt-sidebase-parse-0.2.6.tgz",
+      "integrity": "sha512-I9YolejG6OfFRt/JzYj4FnnQkcCYp9vUdCmOlslAuGrMIFSJmEc9BrT5iN6Vfrd5fKfWFrk7YaEREd+HdcjQ6Q==",
       "dependencies": {
         "h3": "^0.7.21",
         "zod": "^3.19.0"
@@ -24457,9 +24457,9 @@
       }
     },
     "@sidestream-tech/nuxt-sidebase-parse": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@sidestream-tech/nuxt-sidebase-parse/-/nuxt-sidebase-parse-0.2.4.tgz",
-      "integrity": "sha512-QbEAIGHKm0drVlOYSagZMT2eB27rYkwijEIxAjPSrL+soul/aKWUjqc6mL9/koUdUT+DwsTF31Ldd2ruiPNmfg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@sidestream-tech/nuxt-sidebase-parse/-/nuxt-sidebase-parse-0.2.6.tgz",
+      "integrity": "sha512-I9YolejG6OfFRt/JzYj4FnnQkcCYp9vUdCmOlslAuGrMIFSJmEc9BrT5iN6Vfrd5fKfWFrk7YaEREd+HdcjQ6Q==",
       "requires": {
         "h3": "^0.7.21",
         "zod": "^3.19.0"

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
     "story:preview": "histoire preview"
   },
   "dependencies": {
-    "@sidestream-tech/nuxt-sidebase-parse": "^0.2.4",
+    "@sidestream-tech/nuxt-sidebase-parse": "^0.2.6",
     "sqlite3": "^5.0.11",
     "typeorm": "^0.3.9",
     "zod": "^3.18.0"


### PR DESCRIPTION
Only document changes in these two versions.