### PR TITLE
Added TailwindCSS linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
-    "extends": "@antfu/vue",
+    "plugins": ["tailwindcss"],
+    "extends": ["@antfu/vue", "plugin:tailwindcss/recommended"],
     "overrides": [
         {
             "files": [
@@ -21,6 +22,7 @@
             "error",
             "1tbs"
         ],
-        "no-unused-vars": "error"
+        "no-unused-vars": "error",
+        "tailwindcss/no-custom-classname": "off"
     }
 }

--- a/components/example/Status.vue
+++ b/components/example/Status.vue
@@ -17,7 +17,7 @@ defineProps({
       <div>
         Live backend service status is:
       </div>
-      <table class="table-fixed w-full">
+      <table class="w-full table-fixed">
         <tbody>
           <tr>
             <td>

--- a/components/example/__snapshots__/Status.test.ts.snap
+++ b/components/example/__snapshots__/Status.test.ts.snap
@@ -10,7 +10,7 @@ exports[`Status > mounts and is still the same for success variant 1`] = `
 "<div>
   <div>
     <div> Live backend service status is: </div>
-    <table class=\\"table-fixed w-full\\">
+    <table class=\\"w-full table-fixed\\">
       <tbody>
         <tr>
           <td> Status </td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "ant-design-vue": "^3.2.12",
         "babel-loader": "^8.2.4",
         "eslint": "^8.23.0",
+        "eslint-plugin-tailwindcss": "^3.6.2",
         "eslint-plugin-vue": "^9.4.0",
         "histoire": "^0.10.7",
         "husky": "^8.0.1",
@@ -6525,6 +6526,20 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.6.2.tgz",
+      "integrity": "sha512-C9Ka3w6W9F5l/3ZDLnkdbqmeujc1vE+p5drjP1Z1UyxgoE1Nh4/f8oQ4XC45PrZsS0Nyv0YKXNH8/dn/FJZKsQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4",
+        "tailwindcss": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -22905,6 +22920,17 @@
       "integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-tailwindcss": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.6.2.tgz",
+      "integrity": "sha512-C9Ka3w6W9F5l/3ZDLnkdbqmeujc1vE+p5drjP1Z1UyxgoE1Nh4/f8oQ4XC45PrZsS0Nyv0YKXNH8/dn/FJZKsQ==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4",
+        "tailwindcss": "^3.1.3"
+      }
     },
     "eslint-plugin-unicorn": {
       "version": "43.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ant-design-vue": "^3.2.12",
     "babel-loader": "^8.2.4",
     "eslint": "^8.23.0",
+    "eslint-plugin-tailwindcss": "^3.6.2",
     "eslint-plugin-vue": "^9.4.0",
     "histoire": "^0.10.7",
     "husky": "^8.0.1",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,8 +21,8 @@ const ratingValue = ref(5)
 </script>
 
 <template>
-  <div class="h-screen flex items-center justify-center">
-    <div class="w-4/6 max-w-lg flex flex-col">
+  <div class="flex h-screen items-center justify-center">
+    <div class="flex w-4/6 max-w-lg flex-col">
       <SidebaseLogo class="w-72 fill-blue-200" />
       <h1 class="text-xl">
         Welcome to <a href="https://github.com/sidestream-tech/sidebase" target="_blank">sidebase</a>!


### PR DESCRIPTION
Closes #30, closes #31 

I used their recommended presets. The only rule I changed is `tailwindcss/no-custom-classname`, which is enabled by default. The rule throws a warning when a class name is used that is not from tailwindcss and I find that a bit too strict. Otherwise the rules are okay.
Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
